### PR TITLE
Add default OIDC settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__
 .pytest_cache
 .tox
 *.egg-info
+build
+dist
+*.pyc
 
 # VS Code
 .vscode

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -10,6 +10,11 @@ necessary:
 >>> from fpdc_client import FPDC
 >>> server = FPDC(url="http://localhost:8000/")
 
+.. note::
+
+    By default the FPDC client will connect to the production server.
+    You can use the STG_URL global variable to connect to the staging server.
+
 Now connect to the server. This will fetch the available actions from FPDC:
 
 >>> server.connect()
@@ -20,6 +25,11 @@ Authentication
 
 The Fedora servers use OIDC to authenticate, you need to get a ``client_id``
 and a corresponding secret from the OIDC server.
+
+.. note::
+
+    If you are using the production or staging instance of FPDC the client_id and
+    client_secret are automatically provided.
 
 During development, you can use dynamic registration on the development OIDC
 server with the following command::

--- a/fpdc_client/auth.py
+++ b/fpdc_client/auth.py
@@ -28,7 +28,9 @@ class FedoraOIDCAdapter(HTTPAdapter):
         app_id (str): The OpenID Connect application name. You may change it by
             subclassing or right after instanciation. It needs to be a valid
             linux filename, without slashes.
-        config (dict): The client configuration as obtained during registration.
+        client_id (str): The client ID provided by the ID provider service
+        client_secret (str): The client secret provided by the ID provider service
+        id_provider (str): URI of the ID provider
     """
 
     _scopes = [
@@ -38,12 +40,10 @@ class FedoraOIDCAdapter(HTTPAdapter):
         "https://fpdc.fedoraproject.org/oidc/create-release",
     ]
 
-    def __init__(self, app_id, config):
+    def __init__(self, app_id, client_id, client_secret, id_provider):
         super().__init__()
-        id_provider = config["issuer"]
-        client_id = config["client_id"]
         self._oidc_client = OpenIDCBaseClient(
-            app_id, id_provider, client_id, client_secret=config["client_secret"]
+            app_id, id_provider, client_id, client_secret
         )
 
     def send(self, request, **kwargs):


### PR DESCRIPTION
This commit add a default OIDC client ID and
client secret that way anyone use this client
to authenticate against the ID provider

Signed-off-by: Clement Verna <cverna@tutanota.com>