### PR TITLE
Add the ipsilon groups scope.

### DIFF
--- a/fpdc_client/auth.py
+++ b/fpdc_client/auth.py
@@ -36,6 +36,7 @@ class FedoraOIDCAdapter(HTTPAdapter):
         "profile",
         "email",
         "https://fpdc.fedoraproject.org/oidc/create-release",
+        "https://id.fedoraproject.org/scope/groups",
     ]
 
     def __init__(self, app_id, config):


### PR DESCRIPTION
FPDC needs to be able to access the user FAS group
informations to check if they are a member of the allowed
groups.

Signed-off-by: Clement Verna <cverna@tutanota.com>