### PR TITLE
Handle exception raised by a client with wrong permissions.

### DIFF
--- a/fpdc_client/execptions.py
+++ b/fpdc_client/execptions.py
@@ -1,0 +1,20 @@
+"""Exceptions raised by fpdc-client."""
+
+
+class FPDCError(Exception):
+    """The base class for all exceptions raised by fpdc-client."""
+
+
+class PermissionDenied(FPDCError):
+    """
+    Raised when the client does not have the permission to execute an action
+    on the server
+    Args:
+        message (str): A Description of which action was denied
+    """
+
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return f"Permission  Denied: {self.message}"


### PR DESCRIPTION
fpdc checks that the client has the permission to create, update or delete
a ressource. This commit handle the expection raised by coreapi and display
an user friendly message

Signed-off-by: Clement Verna <cverna@tutanota.com>